### PR TITLE
fix error on leaving afk voice channel. closes #17

### DIFF
--- a/slavmain.js
+++ b/slavmain.js
@@ -150,7 +150,8 @@ client.on('voiceStateUpdate', (oldState, newState) => {
     if (
       (oldStateChannel === null ||
         oldState.channelID === oldState.guild.afkChannelID) &&
-      newState.channelID !== newState.guild.afkChannelID
+      newState.channelID !== newState.guild.afkChannelID &&
+      newStateChannel !== null
     ) {
       // For user joining voice, or coming from AFK channel
       console.log('----------');


### PR DESCRIPTION
Fixed the error when leaving a voice channel marked as afk. It's not a pretty solution, and I should fix it properly some day, but today is not that day.