### PR TITLE
Feature/40 twitch alert rewrite

### DIFF
--- a/commands/regtwitch.js
+++ b/commands/regtwitch.js
@@ -1,0 +1,46 @@
+const soundManifest = require('../sound_manifest.json');
+const regUsers = require('../regular_users.json');
+const fs = require('fs').promises;
+const { isAdmin } = require('../utils/isAdmin');
+
+const regtwitch = {
+  name: 'regtwitch',
+  description:
+    'updates the twitch alert sound for given reguser. Set to "none" to remove',
+  execute: function (message, args) {
+    if (args) {
+      const userId = args[0];
+      const twitchSound = args[1];
+      if (isAdmin(message.author.id, true)) {
+        if (
+          twitchSound === 'none' ||
+          ((soundManifest.regularSounds.includes(twitchSound) ||
+            Object.keys(soundManifest).includes(twitchSound)) &&
+            Object.keys(regUsers).includes(userId))
+        ) {
+          regUsers[userId].twitchSound = twitchSound;
+          const regUsersJson = JSON.stringify(regUsers);
+          fs.writeFile('./regular_users.json', regUsersJson, 'utf8')
+            .then(() => {
+              console.log(
+                `User ${regUsers[userId].name} twitch alert sound updated to ${twitchSound}`
+              );
+            })
+            .catch((err) => {
+              console.log(err);
+            });
+        } else {
+          console.log('----------');
+          console.log('User ID or sound were not recognised');
+          console.log(`User ID: ${userId}`);
+          console.log(`Twitch sound: ${twitchSound}`);
+        }
+      }
+    } else {
+      console.log('----------');
+      console.log('No arguments given!');
+    }
+  },
+};
+
+module.exports = regtwitch;

--- a/commands/reguser.js
+++ b/commands/reguser.js
@@ -22,6 +22,7 @@ const reguser = {
                 name: user.username,
                 joinSound: 'none',
                 leaveSound: 'none',
+                twitchSound: 'none',
               };
               const formattedRegUsers = JSON.stringify(regUsers);
               fs.writeFile('./regular_users.json', formattedRegUsers, 'utf8')

--- a/commands/twitchupdate.js
+++ b/commands/twitchupdate.js
@@ -1,0 +1,26 @@
+const fs = require('fs').promises;
+const { isAdmin } = require('../utils/isAdmin');
+
+const twitchupdate = {
+  name: 'twitchupdate',
+  description: 'updates regusers with new twitchsound property',
+  execute: function (message, args) {
+    if (isAdmin(message.author.id, true)) {
+      const regUsers = require('../regular_users.json');
+      Object.keys(regUsers).forEach((userKey) => {
+        regUsers[userKey].twitchSound = 'none';
+      });
+      const regUsersJson = JSON.stringify(regUsers);
+
+      fs.writeFile('./regular_users.json', regUsersJson, 'utf8')
+        .then((res) => {
+          console.log('All regUsers updated with twitchSound property!');
+        })
+        .catch((err) => {
+          console.log(err);
+        });
+    }
+  },
+};
+
+module.exports = twitchupdate;

--- a/slavmain.js
+++ b/slavmain.js
@@ -1,12 +1,5 @@
 // It's slav time
-const {
-  SND_PREFIX,
-  CMD_PREFIX,
-  TOKEN,
-  LOAN_ID,
-  LOAN_TWITCH,
-  INTENTS,
-} = require('./config.json');
+const { SND_PREFIX, CMD_PREFIX, TOKEN, INTENTS } = require('./config.json');
 const { Client } = require('discord.js');
 const fs = require('fs').promises;
 const client = new Client({ intents: INTENTS });

--- a/slavmain.js
+++ b/slavmain.js
@@ -228,51 +228,46 @@ client.on('voiceStateUpdate', (oldState, newState) => {
 });
 
 // Detect someone going live on Twitch and play alert sound if they have one set
-
-// TODO: add handling for users not on reguser list
-
 client.on('presenceUpdate', (oldPresence, newPresence) => {
-  console.log(regUsers[newPresence.user.id.toString()]);
-  newPresence.activities.forEach((activity) => {
-    console.log(activity.type);
-  });
-
-  if (regUsers[newPresence.user.id.toString()].twitchSound != 'none') {
-    console.log('yeet');
-    // Make sure the update is an actual change, is Twitch, and that it's the first update containing twitch
-    let oldPresenceNotTwitch = true;
-    if (typeof oldPresence !== undefined) {
-      oldPresence.activities.forEach((activity) => {
-        if (activity.type === 'STREAMING') {
-          oldPresenceNotTwitch = false;
-        }
-      });
-      if (oldPresenceNotTwitch) {
-        newPresence.activities.forEach((activity) => {
-          if (
-            !newPresence.equals(oldPresence) &&
-            activity.type === 'STREAMING'
-          ) {
-            const firstChannel = newPresence.guild.channels.cache
-              .filter((channel) => channel.isVoice())
-              .first();
-
-            console.log('----------');
-            console.log(
-              `${newPresence.user.username} has gone live on ${activity.name}`
-            );
-
-            playSound(
-              regUsers[newPresence.user.id.toString()].twitchSound,
-              firstChannel
-            );
+  if (Object.keys(regUsers).includes(newPresence.user.id.toString())) {
+    if (regUsers[newPresence.user.id.toString()].twitchSound != 'none') {
+      // Make sure the update is an actual change, is Twitch, and that it's the first update containing twitch
+      let oldPresenceNotTwitch = true;
+      if (typeof oldPresence !== undefined) {
+        oldPresence.activities.forEach((activity) => {
+          if (activity.type === 'STREAMING') {
+            oldPresenceNotTwitch = false;
           }
         });
+        if (oldPresenceNotTwitch) {
+          newPresence.activities.forEach((activity) => {
+            if (
+              !newPresence.equals(oldPresence) &&
+              activity.type === 'STREAMING'
+            ) {
+              const firstChannel = newPresence.guild.channels.cache
+                .filter((channel) => channel.isVoice())
+                .first();
+
+              console.log('----------');
+              console.log(
+                `${newPresence.user.username} has gone live on ${activity.name}`
+              );
+
+              playSound(
+                regUsers[newPresence.user.id.toString()].twitchSound,
+                firstChannel
+              );
+            }
+          });
+        }
+      } else {
+        console.log('----------');
+        console.log('oldPresence was undefined');
       }
-    } else {
-      console.log('----------');
-      console.log('oldPresence was undefined');
     }
+  } else {
+    console.log(`${newPresence.user.username} is not a regular user`);
   }
 });
 


### PR DESCRIPTION
Rewrote twitch alert function to work for all regusers. For migration of old regular_users.json first run `twitchupdate`, then after that use `regtwitch` to set twitch alert sounds the same as join/leave sounds.

Closes #40 